### PR TITLE
fixBug:当方法上的Mapping注解没有写具体的url时应取baseUrl，不应该再拼接方法名作为url

### DIFF
--- a/library/src/main/java/io/github/yedaxia/apidocs/Utils.java
+++ b/library/src/main/java/io/github/yedaxia/apidocs/Utils.java
@@ -130,6 +130,10 @@ public class Utils {
 		if(baseUrl == null){
 			return relativeUrl;
 		}
+		//当注解没写url时会默认取方法名，这里改掉。
+		if("".equals(relativeUrl)){
+			return baseUrl;
+		}
 
 		if(baseUrl.endsWith("/")){
 			baseUrl = baseUrl.substring(0, baseUrl.length() - 1);

--- a/library/src/main/java/io/github/yedaxia/apidocs/parser/AbsControllerParser.java
+++ b/library/src/main/java/io/github/yedaxia/apidocs/parser/AbsControllerParser.java
@@ -102,7 +102,7 @@ public abstract class AbsControllerParser {
                     requestNode.setControllerNode(controllerNode);
                     requestNode.setAuthor(controllerNode.getAuthor());
                     requestNode.setMethodName(m.getNameAsString());
-                    requestNode.setUrl(requestNode.getMethodName());
+                    requestNode.setUrl("");
                     requestNode.setDescription(requestNode.getMethodName());
 
                     m.getAnnotationByClass(Deprecated.class).ifPresent(f -> {


### PR DESCRIPTION
将默认方法名作为url改为了空字符串，url拼接时如果为空字符串则返回baseUrl