### PR TITLE
修复接口入参javadoc只写@param，不加参数时导致html不能正常生成问题

### DIFF
--- a/library/src/main/resources/api-doc.md.ftl
+++ b/library/src/main/resources/api-doc.md.ftl
@@ -25,7 +25,8 @@ ${i18n.getMessage('parameterName')}|${i18n.getMessage('parameterType')}|${i18n.g
 --:|:--:|:--:|:--
         <#list reqNode.paramNodes as paramNode>
             <#if !(paramNode.jsonBody)>
-${paramNode.name}|${paramNode.type}|${paramNode.required?string(i18n.getMessage('yes'),i18n.getMessage('no'))}|${(paramNode.description)!''}
+<#--${paramNode.name}|${paramNode.type}|${paramNode.required?string(i18n.getMessage('yes'),i18n.getMessage('no'))}|${(paramNode.description)!''}-->
+${paramNode.name}|<#if paramNode.type??>${paramNode.type}</#if>|${paramNode.required?string(i18n.getMessage('yes'),i18n.getMessage('no'))}|${(paramNode.description)!''}
             </#if>
         </#list>
     </#if>

--- a/library/src/main/resources/api-request-node.html.ftl
+++ b/library/src/main/resources/api-request-node.html.ftl
@@ -38,7 +38,8 @@
                 <#if !(paramNode.jsonBody)>
                     <tr>
                         <td>${paramNode.name}</td>
-                        <td>${paramNode.type}</td>
+                        <#--<td>${paramNode.type}</td>-->
+                        <td><#if paramNode.type??>${paramNode.type}</#if></td>
                         <td>${paramNode.required?string(i18n.getMessage('yes'),i18n.getMessage('no'))}</td>
                         <td>${(paramNode.description)!''}</td>
                     </tr>


### PR DESCRIPTION
修复接口入参javadoc只写@param，不加参数时，freemarker解析模板抛出异常(FreeMarker template error (DEBUG mode; use RETHROW in production!))，导致html不能正常生成问题